### PR TITLE
modify oasim to run with ufo

### DIFF
--- a/src/oasim/daysetrad_mod.f90
+++ b/src/oasim/daysetrad_mod.f90
@@ -35,6 +35,9 @@ integer :: k
 ! Parameters
 real(kind=kind_real), parameter :: sday=86400.0_kind_real  !seconds per day
 
+!Initialize avgq 
+avgq(:) = 1.0_kind_real
+
 ! Compute average quanta; Initialize light history arrays
 do k = 1,km
   avgq(k) = avgq(k)*sday/dt

--- a/src/oasim/edeu_mod.f90
+++ b/src/oasim/edeu_mod.f90
@@ -76,12 +76,14 @@ real(kind=kind_real), parameter :: dmax      = 500.0_kind_real     !depth at whi
 
 !  Constants and initialize
 rmus = 1.0_kind_real/0.83_kind_real            !avg cosine diffuse down
-tirrq = 0.0_kind_real
-cdomabsq = 0.0_kind_real
-deltaE = 0.0_kind_real
-acdom = 0.0_kind_real
-
+tirrq(:) = 0.0_kind_real
+cdomabsq(:) = 0.0_kind_real
+deltaE(:) = 0.0_kind_real
+acdom(:) = 0.0_kind_real
+avgq(:) = 0.0_kind_real
 Ebot = 0.0_kind_real
+bbrw    = 1.0_kind_real ! we need to confirm with Cecile
+
 do nl = 1,nlt
 !do nl = npst,npnd
   Edtop(nl) = Ed(nl)

--- a/src/oasim/edeu_mod.f90
+++ b/src/oasim/edeu_mod.f90
@@ -82,7 +82,7 @@ deltaE(:) = 0.0_kind_real
 acdom(:) = 0.0_kind_real
 avgq(:) = 0.0_kind_real
 Ebot = 0.0_kind_real
-bbrw    = 1.0_kind_real ! we need to confirm with Cecile
+bbrw    = 0.5_kind_real ! we need to confirm with Cecile
 
 do nl = 1,nlt
 !do nl = npst,npnd

--- a/src/oasim/oasim_mod.f90
+++ b/src/oasim/oasim_mod.f90
@@ -28,7 +28,7 @@ type :: oasim
   real(kind=kind_real), allocatable :: asl(:), bsl(:), csl(:), dsl(:), esl(:), fsl(:)
   contains
     procedure, public :: create
-    procedure, public :: delete
+    procedure, public :: cancel
     procedure, public :: run
     final :: dummy_final
 endtype oasim
@@ -85,7 +85,7 @@ end subroutine create
 
 ! --------------------------------------------------------------------------------------------------
 
-subroutine delete(self)
+subroutine cancel(self)
 
 ! Arguments
 class(oasim), intent(inout) :: self
@@ -115,7 +115,7 @@ deallocate(self%dsl)
 deallocate(self%esl)
 deallocate(self%fsl)
 
-end subroutine delete
+end subroutine cancel
 
 ! --------------------------------------------------------------------------------------------------
 

--- a/src/oasim/oasim_mod.f90
+++ b/src/oasim/oasim_mod.f90
@@ -157,7 +157,7 @@ real(kind=kind_real), intent(out) :: cdomabsq(km) ! Absorption of quanta by CDOM
 real(kind=kind_real), intent(out) :: avgq(km)     ! Average quantum irradiance (Average quantum irradiance)
 
 ! Locals
-integer :: lm, nl
+integer :: nl
 real(kind=kind_real) :: relhum, daycor, rday, sunz
 real(kind=kind_real) :: ed(nlt), es(nlt), rod(nlt), ros(nlt), ta(nlt), wa(nlt)
 real(kind=kind_real), allocatable :: phyto(:,:)
@@ -165,7 +165,7 @@ real(kind=kind_real), allocatable :: phyto(:,:)
 
 ! Set the phyto variable
 ! ----------------------
-allocate(phyto(lm,ntyp))
+allocate(phyto(km,6))
 phyto(:,1) = diatom
 phyto(:,2) = chloro
 phyto(:,3) = cyano
@@ -216,10 +216,9 @@ if (dh(1) < 1.0e10_kind_real .and. cosz > 0.0_kind_real) then
     enddo
 
     ! Spectral irradiance in the water column
-    call glight(lm, is_midnight, cosz, self%lam, self%aw, self%bw, self%ac, self%bc, self%bpic, &
+    call glight(km, is_midnight, cosz, self%lam, self%aw, self%bw, self%ac, self%bc, self%bpic, &
                 self%excdom, self%exdet, self%wtoq, ed, es, dh, phyto, cdet, pic, cdc, tirrq, &
                 cdomabsq, avgq, dt)
-
   endif
 
 endif

--- a/src/oasim/oasim_mod.f90
+++ b/src/oasim/oasim_mod.f90
@@ -28,7 +28,7 @@ type :: oasim
   real(kind=kind_real), allocatable :: asl(:), bsl(:), csl(:), dsl(:), esl(:), fsl(:)
   contains
     procedure, public :: create
-    procedure, public :: cancel
+    procedure, public :: delete
     procedure, public :: run
     final :: dummy_final
 endtype oasim
@@ -85,7 +85,7 @@ end subroutine create
 
 ! --------------------------------------------------------------------------------------------------
 
-subroutine cancel(self)
+subroutine delete(self)
 
 ! Arguments
 class(oasim), intent(inout) :: self
@@ -115,7 +115,7 @@ deallocate(self%dsl)
 deallocate(self%esl)
 deallocate(self%fsl)
 
-end subroutine cancel
+end subroutine delete
 
 ! --------------------------------------------------------------------------------------------------
 

--- a/src/oasim/setlte_mod.f90
+++ b/src/oasim/setlte_mod.f90
@@ -54,7 +54,7 @@ real(kind=kind_real), parameter :: b3 = -2.698E-9_kind_real
 ! Sets parameters for ocean irradiance.
 
 ! Obtain Light data
-!call lidata(lam, aw, bw, ac, bc, bpic, data_directory)
+call lidata(lam, aw, bw, ac, bc, bpic, data_directory)
 
 ! Quanta conversion
 planck = 6.6256E-34_kind_real   !Plancks constant J sec

--- a/test/test_oasim.f90
+++ b/test/test_oasim.f90
@@ -13,6 +13,6 @@ print*, 'Running oasim test'
 call oasim_obj%create('data')
 
 ! Run the deallocate
-call oasim_obj%delete()
+call oasim_obj%cancel()
 
 end program oasim_test

--- a/test/test_oasim.f90
+++ b/test/test_oasim.f90
@@ -13,6 +13,6 @@ print*, 'Running oasim test'
 call oasim_obj%create('data')
 
 ! Run the deallocate
-call oasim_obj%cancel()
+call oasim_obj%delete()
 
 end program oasim_test


### PR DESCRIPTION
## Description

I modified oasim a little bit to make it work with the https://github.com/JCSDA-internal/ufo/tree/feature/oasim_run, having a subroutine named "delete" in both ufo and oasim was causing error, I renamed it here to "cancel" to resolve the issue, but I'm open to suggestions. also the subroutine lidata was commented here after discussion with Cecile it turned out it should be uncommented

### Issue(s) addressed

this is needed for the issue "hookup non-linear part of OASIM  #2169"

I