### PR TITLE
removing cldtau and cldre

### DIFF
--- a/src/oasim/oasim_mod.f90
+++ b/src/oasim/oasim_mod.f90
@@ -121,7 +121,7 @@ end subroutine delete
 ! --------------------------------------------------------------------------------------------------
 
 subroutine run(self, km, dt, is_midnight, day_of_year, cosz, l_chan, slp, wspd, ozone, wvapor, rh, cov, &
-               clwp, cldre, ta_in, wa_in, asym, dh, cdet, pic, cdc, diatom, chloro, cyano, &
+               clwp, ta_in, wa_in, asym, dh, cdet, pic, cdc, diatom, chloro, cyano, &
                cocco, dino, phaeo, tirrq, cdomabsq, avgq, rlwnref)
 
 ! Arguments
@@ -139,7 +139,6 @@ real(kind=kind_real), intent(in)  :: wvapor       ! Water vapor (cm)
 real(kind=kind_real), intent(in)  :: rh           ! Relative humidity (percent)
 real(kind=kind_real), intent(in)  :: cov          ! Cloud cover (percent)
 real(kind=kind_real), intent(in)  :: clwp         ! Cloud liquid water path (dimensionless)
-real(kind=kind_real), intent(in)  :: cldre        ! Cloud droplet effective radius (dimensionless)
 real(kind=kind_real), intent(in)  :: ta_in(nlt)   ! Aerosol optical thickness (dimensionless)
 real(kind=kind_real), intent(in)  :: wa_in(nlt)   ! Single scattering albedo (dimensionless)
 real(kind=kind_real), intent(in)  :: asym(nlt)    ! Asymmetry parameter (dimensionless)
@@ -206,7 +205,7 @@ if (dh(1) < 1.0e10_kind_real .and. cosz > 0.0_kind_real) then
     call sfcirr(self%lam, self%fobar, self%thray, self%oza, self%awv, self%ao, self%aco2, &
                 self%asl, self%bsl, self%csl, self%dsl, self%esl, self%fsl, self%ica, daycor, &
                 cosz, slp, wspd, ozone, wvapor, relhum, ta, wa, asym, self%am, self%vi, cov, &
-                clwp, cldre, ed, es)
+                clwp, ed, es)
 
     ! Spectral irradiance just below surface
     sunz = acos(cosz)*self%rad

--- a/src/oasim/oasim_mod.f90
+++ b/src/oasim/oasim_mod.f90
@@ -121,7 +121,7 @@ end subroutine delete
 ! --------------------------------------------------------------------------------------------------
 
 subroutine run(self, km, dt, is_midnight, day_of_year, cosz, l_chan, slp, wspd, ozone, wvapor, rh, cov, &
-               cldtau, clwp, cldre, ta_in, wa_in, asym, dh, cdet, pic, cdc, diatom, chloro, cyano, &
+               clwp, cldre, ta_in, wa_in, asym, dh, cdet, pic, cdc, diatom, chloro, cyano, &
                cocco, dino, phaeo, tirrq, cdomabsq, avgq, rlwnref)
 
 ! Arguments
@@ -138,7 +138,6 @@ real(kind=kind_real), intent(in)  :: ozone        ! Ozone thickness (dobson unit
 real(kind=kind_real), intent(in)  :: wvapor       ! Water vapor (cm)
 real(kind=kind_real), intent(in)  :: rh           ! Relative humidity (percent)
 real(kind=kind_real), intent(in)  :: cov          ! Cloud cover (percent)
-real(kind=kind_real), intent(in)  :: cldtau       ! Cloud optical thickness (dimensionless)
 real(kind=kind_real), intent(in)  :: clwp         ! Cloud liquid water path (dimensionless)
 real(kind=kind_real), intent(in)  :: cldre        ! Cloud droplet effective radius (dimensionless)
 real(kind=kind_real), intent(in)  :: ta_in(nlt)   ! Aerosol optical thickness (dimensionless)
@@ -207,7 +206,7 @@ if (dh(1) < 1.0e10_kind_real .and. cosz > 0.0_kind_real) then
     call sfcirr(self%lam, self%fobar, self%thray, self%oza, self%awv, self%ao, self%aco2, &
                 self%asl, self%bsl, self%csl, self%dsl, self%esl, self%fsl, self%ica, daycor, &
                 cosz, slp, wspd, ozone, wvapor, relhum, ta, wa, asym, self%am, self%vi, cov, &
-                cldtau, clwp, cldre, ed, es)
+                clwp, cldre, ed, es)
 
     ! Spectral irradiance just below surface
     sunz = acos(cosz)*self%rad

--- a/src/oasim/sfcirr_mod.f90
+++ b/src/oasim/sfcirr_mod.f90
@@ -24,7 +24,7 @@ contains
 
 subroutine sfcirr(lam, fobar, thray, oza, awv, ao, aco2, asl, bsl, csl, dsl, esl, fsl, ica, &
                   daycor, cosunz, pres, ws, ozone, wvapor, relhum, ta, wa, asym, am, vi, cov, &
-                  clwp, re, ed, es)
+                  clwp, ed, es)
 
 ! Calls clrtrans to get cloud-free transmittance and slingo to
 ! get cloudy transmittance, then computes total irradiance in
@@ -64,7 +64,6 @@ real(kind=kind_real), intent(in)    :: am
 real(kind=kind_real), intent(in)    :: vi
 real(kind=kind_real), intent(in)    :: cov
 real(kind=kind_real), intent(in)    :: clwp
-real(kind=kind_real), intent(in)    :: re
 real(kind=kind_real), intent(out)   :: ed(nlt)
 real(kind=kind_real), intent(out)   :: es(nlt)
 
@@ -138,7 +137,7 @@ do nl = 1,nlt
 enddo    !end clear nl loop
 
 !  Compute cloudy transmittances
-call slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, clwp, re, tdcld, tscld)
+call slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, clwp, tdcld, tscld)
 
 do nl = 1,nlt
   foinc = fobar(nl)*daycor*cosunz

--- a/src/oasim/sfcirr_mod.f90
+++ b/src/oasim/sfcirr_mod.f90
@@ -24,7 +24,7 @@ contains
 
 subroutine sfcirr(lam, fobar, thray, oza, awv, ao, aco2, asl, bsl, csl, dsl, esl, fsl, ica, &
                   daycor, cosunz, pres, ws, ozone, wvapor, relhum, ta, wa, asym, am, vi, cov, &
-                  cldtau, clwp, re, ed, es)
+                  clwp, re, ed, es)
 
 ! Calls clrtrans to get cloud-free transmittance and slingo to
 ! get cloudy transmittance, then computes total irradiance in
@@ -63,7 +63,6 @@ real(kind=kind_real), intent(in)    :: asym(nlt)
 real(kind=kind_real), intent(in)    :: am
 real(kind=kind_real), intent(in)    :: vi
 real(kind=kind_real), intent(in)    :: cov
-real(kind=kind_real), intent(in)    :: cldtau
 real(kind=kind_real), intent(in)    :: clwp
 real(kind=kind_real), intent(in)    :: re
 real(kind=kind_real), intent(out)   :: ed(nlt)
@@ -139,7 +138,7 @@ do nl = 1,nlt
 enddo    !end clear nl loop
 
 !  Compute cloudy transmittances
-call slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, cldtau, clwp, re, tdcld, tscld)
+call slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, clwp, re, tdcld, tscld)
 
 do nl = 1,nlt
   foinc = fobar(nl)*daycor*cosunz

--- a/src/oasim/slingo_mod.f90
+++ b/src/oasim/slingo_mod.f90
@@ -20,14 +20,13 @@ contains
 
 ! --------------------------------------------------------------------------------------------------
 
-subroutine slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, clwp, cre, tcd, tcs)
+subroutine slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, clwp, tcd, tcs)
 
 !  Slingo's (1989) Delta-Eddington approximation for the two-
 !  stream equations applied to clouds.
 !  Inputs:
 !       rmu0    Kasten's approx for cosine of solar zenith angle
 !       clwp    liquid water path in cloud (g/m2)
-!       cre     cloud droplet effective radius (um)
 !  Outputs
 !       ica     index for translating cloud arrays to light arrays
 !       Tcd     spectral transmittance for downwelling direct irradiance
@@ -45,7 +44,6 @@ real(kind=kind_real), intent(in)  :: esl(ncld)
 real(kind=kind_real), intent(in)  :: fsl(ncld)
 real(kind=kind_real), intent(in)  :: rmu0
 real(kind=kind_real), intent(in)  :: clwp
-real(kind=kind_real), intent(in)  :: cre
 real(kind=kind_real), intent(out) :: tcd(ncld)
 real(kind=kind_real), intent(out) :: tcs(ncld)
 

--- a/src/oasim/slingo_mod.f90
+++ b/src/oasim/slingo_mod.f90
@@ -20,13 +20,12 @@ contains
 
 ! --------------------------------------------------------------------------------------------------
 
-subroutine slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, cldtau, clwp, cre, tcd, tcs)
+subroutine slingo(asl, bsl, csl, dsl, esl, fsl, rmu0, clwp, cre, tcd, tcs)
 
 !  Slingo's (1989) Delta-Eddington approximation for the two-
 !  stream equations applied to clouds.
 !  Inputs:
 !       rmu0    Kasten's approx for cosine of solar zenith angle
-!       cldtau  cloud optical thickness (at 0.6 um)
 !       clwp    liquid water path in cloud (g/m2)
 !       cre     cloud droplet effective radius (um)
 !  Outputs
@@ -45,7 +44,6 @@ real(kind=kind_real), intent(in)  :: dsl(ncld)
 real(kind=kind_real), intent(in)  :: esl(ncld)
 real(kind=kind_real), intent(in)  :: fsl(ncld)
 real(kind=kind_real), intent(in)  :: rmu0
-real(kind=kind_real), intent(in)  :: cldtau
 real(kind=kind_real), intent(in)  :: clwp
 real(kind=kind_real), intent(in)  :: cre
 real(kind=kind_real), intent(out) :: tcd(ncld)
@@ -59,29 +57,9 @@ real(kind=kind_real) :: re, remean, tauc, oneomega, omega, g
 Tcd = 0.0_kind_real
 Tcs = 0.0_kind_real
 
-!  Compute re as funtion of cldtau and LWP according to eq. 1 in
-!  Slingo.
-!   tau is derived at this wavelength (0.6 um) in the ISCCP data set
-!      re = clwp*bsl(9)/(cldtau - clwp*asl(9))
-!      re = min(re,15.0)  !block high re -- produces excessive direct
-!  Changes to the ISCCP-D2 data set make this relationship untenable
-!  (excessive re's are derived).  Instead choose a fixed re of 10 um
-!  for ocean (Kiehl et al., 1998 -- J. Clim.)
-!       re = 10.0
-!  Paper by Han et al., 1994 (J.Clim.) show mean ocean cloud radius
-!  = 11.8 um
-!       re = 11.8
-
 ! Mean of Kiehl and Han
 re = (10.0_kind_real+11.8_kind_real)/2.0_kind_real
 remean = re
-
-! Compute spectral cloud characteristics
-! If MODIS re is available use it; otherwise use parameterized re above
-! I comment this part for now as it cause errors at some profiles, will revisit this later
-!if (cre .ge. 0.0_kind_real) then   !use modis re
-!  re = cre
-!endif
 
 do nc = 1,22
   tauc = clwp*(asl(nc)+bsl(nc)/re)


### PR DESCRIPTION
## Description

The cldtau or cloud optical thickness and  cldre (Cloud droplet effective radius) are not used in oasim anymore, they have been there before as they have been included in MODIS data, but they have been commented out later on in OASIM, so we just removed them from input lists

## Issue(s) addressed

closes #6 https://github.com/JCSDA-internal/oasim/issues/6

## Dependencies

this PR needs to be merged with the corresponding PRS in UFO and SOCA

List the other PRs that this PR is dependent on:

https://github.com/JCSDA-internal/ufo/pull/3179
https://github.com/JCSDA-internal/soca/pull/1006



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the unit tests before creating the PR
